### PR TITLE
Fix 2 bugs which cause build failing.

### DIFF
--- a/Core/QuantumMachine/QCloudMachine.cpp
+++ b/Core/QuantumMachine/QCloudMachine.cpp
@@ -1,3 +1,4 @@
+#ifdef USE_CURL
 #include <fstream>
 #include <math.h>
 #include <algorithm>
@@ -343,4 +344,5 @@ std::string QCloudMachine::parserRecvJson
 }
 
 REGISTER_QUANTUM_MACHINE(QCloudMachine);
+#endif //USE_CURL
 

--- a/include/Core/QuantumMachine/QCloudMachine.h
+++ b/include/Core/QuantumMachine/QCloudMachine.h
@@ -6,7 +6,6 @@
 
 #ifdef USE_CURL
 #include <curl/curl.h>
-#endif // USE_CURL
 
 #include "ThirdParty/rapidjson/document.h"
 #include "ThirdParty/rapidjson/writer.h"
@@ -114,4 +113,6 @@ std::string QProgToBinary(QProg,QuantumMachine*);
 
 
 QPANDA_END
+
 #endif // USE_CURL
+#endif // ! QCLOUD_MACHINE_H

--- a/pyQPandaCpp/pyQPanda.Core/pyqpanda.core.cpp
+++ b/pyQPandaCpp/pyQPanda.Core/pyqpanda.core.cpp
@@ -427,10 +427,6 @@ PYBIND11_MODULE(pyQPanda, m)
         py::return_value_policy::automatic_reference
     );
 
-    m.def("get_bin_str", &QProgToBinary, "program"_a, "qvm"_a, "Get quantum program binary data string",
-        py::return_value_policy::automatic_reference
-    );
-
     m.def("bin_to_prog", &binaryQProgDataParse, "qvm"_a, "data"_a, "qlist"_a, "clist"_a, "program"_a,
         "Parse quantum program interface for  binary data vector",
         py::return_value_policy::automatic_reference


### PR DESCRIPTION
1. USE_CURL macro does not correctly wrap the header and source file.
2. Remove a wrapper function in pyQPanda which no longer exists.